### PR TITLE
Hacktoberfest

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ Docker images are also available:
 
 `github-download-stats` can be installed from source by running:
 
-    go get -u github.com/andrewsomething/github-download-stats
+#### Go Version 1.16 and Earlier
+`go get -u github.com/andrewsomething/github-download-stats`
+
+#### Go Version 1.17 and Later
+`go install github.com/andrewsomething/github-download-stats@latest`
 
 ## Usage
 
@@ -32,6 +36,18 @@ Usage of ./github-download-stats:
     	GitHub API token (default "")
   -version
     	Print version
+```
+### Usage for Get Stats for All Releases
+```
+github-download-stats -owner <owner> -repo <repo> -token <your_token>
+```
+### Usage for Get Stats for Spesific Releases
+```
+github-download-stats -owner <owner> -repo <repo> -release <release_tag> -token <your_token>
+```
+### Usage for Get Stats in JSON
+```
+github-download-stats -owner <owner> -repo <repo> -json -token <your_token>
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -13,10 +13,16 @@ Docker images are also available:
 `github-download-stats` can be installed from source by running:
 
 #### Go Version 1.16 and Earlier
-`go get -u github.com/andrewsomething/github-download-stats`
+
+```
+go get -u github.com/andrewsomething/github-download-stats
+```
 
 #### Go Version 1.17 and Later
-`go install github.com/andrewsomething/github-download-stats@latest`
+
+```
+go install github.com/andrewsomething/github-download-stats@latest
+```
 
 ## Usage
 
@@ -38,14 +44,17 @@ Usage of ./github-download-stats:
     	Print version
 ```
 ### Usage for Get Stats for All Releases
+
 ```
 github-download-stats -owner <owner> -repo <repo> -token <your_token>
 ```
-### Usage for Get Stats for Spesific Releases
+### Usage for Get Stats for Specific Releases
+
 ```
 github-download-stats -owner <owner> -repo <repo> -release <release_tag> -token <your_token>
 ```
 ### Usage for Get Stats in JSON
+
 ```
 github-download-stats -owner <owner> -repo <repo> -json -token <your_token>
 ```


### PR DESCRIPTION
**Background**

- Command installation binaries not supported for go version v1.17^ and later
- We need more example API usage

**Solution**
- Updated command installation for go v1.16 and earlier, and command instruction for go version v1.17 and later
- Add 3 example usage for All Release, Specific Release, and output with JSON